### PR TITLE
Remove genesis hack

### DIFF
--- a/src/builder_state.rs
+++ b/src/builder_state.rs
@@ -565,14 +565,6 @@ impl<TYPES: NodeType> BuilderProgress<TYPES> for BuilderState<TYPES> {
             quorum_proposal.block_header.builder_commitment();
         let mut leaf = Leaf::from_quorum_proposal(&quorum_proposal);
 
-        // Hack for genesis mishandling in HotShot.
-        // Once the is_genesis field is removed, you can delete this block.
-        if quorum_proposal.justify_qc.is_genesis {
-            // get the instance state from the global state
-            let instance_state = &self.global_state.read_arc().await.instance_state;
-            leaf.set_parent_commitment(Leaf::genesis(instance_state).commit());
-        }
-
         self.built_from_proposed_block.leaf_commit = leaf.commit();
 
         let payload = <TYPES::BlockPayload as BlockPayload>::from_bytes(

--- a/src/builder_state.rs
+++ b/src/builder_state.rs
@@ -242,7 +242,7 @@ impl<TYPES: NodeType> BuilderProgress<TYPES> for BuilderState<TYPES> {
     }
 
     /// processing the hotshot i.e public mempool transaction
-    #[tracing::instrument(skip_all, name = "process hotshot transaction", 
+    #[tracing::instrument(skip_all, name = "process hotshot transaction",
                                     fields(builder_built_from_proposed_block = %self.built_from_proposed_block))]
     fn process_hotshot_transaction(&mut self, tx: TYPES::Transaction) {
         tracing::info!("Processing hotshot transaction");
@@ -382,7 +382,7 @@ impl<TYPES: NodeType> BuilderProgress<TYPES> for BuilderState<TYPES> {
 
     /// processing the quorum proposal
     //#[tracing::instrument(skip_all, name = "Process Quorum Proposal")]
-    #[tracing::instrument(skip_all, name = "process quorum proposal", 
+    #[tracing::instrument(skip_all, name = "process quorum proposal",
                                     fields(builder_built_from_proposed_block = %self.built_from_proposed_block))]
     async fn process_quorum_proposal(&mut self, qc_msg: QCMessage<TYPES>) {
         tracing::debug!(
@@ -408,8 +408,7 @@ impl<TYPES: NodeType> BuilderProgress<TYPES> for BuilderState<TYPES> {
         } else if qc_msg.proposal.data.justify_qc.view_number
             != self.built_from_proposed_block.view_number
             || (qc_msg.proposal.data.justify_qc.get_data().leaf_commit
-                != self.built_from_proposed_block.leaf_commit
-               )
+                != self.built_from_proposed_block.leaf_commit)
         {
             tracing::info!("Either View number {:?} or leaf commit{:?} from justify qc does not match the built-in info {:?}, so returning",
             qc_msg.proposal.data.justify_qc.view_number, qc_msg.proposal.data.justify_qc.get_data().leaf_commit, self.built_from_proposed_block);
@@ -467,7 +466,7 @@ impl<TYPES: NodeType> BuilderProgress<TYPES> for BuilderState<TYPES> {
     }
 
     /// processing the decide event
-    #[tracing::instrument(skip_all, name = "process decide event", 
+    #[tracing::instrument(skip_all, name = "process decide event",
                                    fields(builder_built_from_proposed_block = %self.built_from_proposed_block))]
     async fn process_decide_event(&mut self, decide_msg: DecideMessage<TYPES>) -> Option<Status> {
         // special clone already launched the clone, then exit
@@ -550,7 +549,7 @@ impl<TYPES: NodeType> BuilderProgress<TYPES> for BuilderState<TYPES> {
     }
 
     // spawn a clone of the builder state
-    #[tracing::instrument(skip_all, name = "spawn_clone", 
+    #[tracing::instrument(skip_all, name = "spawn_clone",
                                     fields(builder_built_from_proposed_block = %self.built_from_proposed_block))]
     async fn spawn_clone(
         mut self,
@@ -563,7 +562,7 @@ impl<TYPES: NodeType> BuilderProgress<TYPES> for BuilderState<TYPES> {
             quorum_proposal.block_header.payload_commitment();
         self.built_from_proposed_block.builder_commitment =
             quorum_proposal.block_header.builder_commitment();
-        let mut leaf = Leaf::from_quorum_proposal(&quorum_proposal);
+        let leaf = Leaf::from_quorum_proposal(&quorum_proposal);
 
         self.built_from_proposed_block.leaf_commit = leaf.commit();
 
@@ -593,7 +592,7 @@ impl<TYPES: NodeType> BuilderProgress<TYPES> for BuilderState<TYPES> {
     }
 
     // build a block
-    #[tracing::instrument(skip_all, name = "build block", 
+    #[tracing::instrument(skip_all, name = "build block",
                                     fields(builder_built_from_proposed_block = %self.built_from_proposed_block))]
     async fn build_block(&mut self, _matching_vid: VidCommitment) -> Option<BuildBlockInfo<TYPES>> {
         if let Ok((payload, metadata)) = <TYPES::BlockPayload as BlockPayload>::from_transactions(
@@ -701,7 +700,7 @@ impl<TYPES: NodeType> BuilderProgress<TYPES> for BuilderState<TYPES> {
             tracing::info!("Builder {:?} Requested Builder commitment does not match the built_from_view, so ignoring it", self.built_from_proposed_block);
         }
     }
-    #[tracing::instrument(skip_all, name = "event loop", 
+    #[tracing::instrument(skip_all, name = "event loop",
                                     fields(builder_built_from_proposed_block = %self.built_from_proposed_block))]
     fn event_loop(mut self) {
         let _builder_handle = async_spawn(async move {

--- a/src/builder_state.rs
+++ b/src/builder_state.rs
@@ -409,7 +409,7 @@ impl<TYPES: NodeType> BuilderProgress<TYPES> for BuilderState<TYPES> {
             != self.built_from_proposed_block.view_number
             || (qc_msg.proposal.data.justify_qc.get_data().leaf_commit
                 != self.built_from_proposed_block.leaf_commit
-                && !qc_msg.proposal.data.justify_qc.is_genesis)
+               )
         {
             tracing::info!("Either View number {:?} or leaf commit{:?} from justify qc does not match the built-in info {:?}, so returning",
             qc_msg.proposal.data.justify_qc.view_number, qc_msg.proposal.data.justify_qc.get_data().leaf_commit, self.built_from_proposed_block);

--- a/src/service.rs
+++ b/src/service.rs
@@ -617,12 +617,6 @@ async fn handle_qc_event<Types: NodeType>(
 
     let mut leaf = Leaf::from_quorum_proposal(&qc_proposal.data);
 
-    // Hack for genesis mishandling in HotShot.
-    // Once the is_genesis field is removed, you can delete this block.
-    if qc_proposal.data.justify_qc.is_genesis {
-        leaf.set_parent_commitment(Leaf::genesis(instance_state).commit());
-    }
-
     // check if the sender is the leader and the signature is valid; if yes, broadcast the QC proposal
     if sender == leader && sender.validate(&qc_proposal.signature, leaf.commit().as_ref()) {
         let qc_msg = QCMessage::<Types> {

--- a/src/service.rs
+++ b/src/service.rs
@@ -607,7 +607,7 @@ async fn handle_qc_event<Types: NodeType>(
     qc_proposal: Proposal<Types, QuorumProposal<Types>>,
     sender: <Types as NodeType>::SignatureKey,
     leader: <Types as NodeType>::SignatureKey,
-    instance_state: &Types::InstanceState,
+    _instance_state: &Types::InstanceState,
 ) {
     tracing::debug!(
         "QCProposal: Leader: {:?} for the view: {:?}",
@@ -615,7 +615,7 @@ async fn handle_qc_event<Types: NodeType>(
         qc_proposal.data.view_number
     );
 
-    let mut leaf = Leaf::from_quorum_proposal(&qc_proposal.data);
+    let leaf = Leaf::from_quorum_proposal(&qc_proposal.data);
 
     // check if the sender is the leader and the signature is valid; if yes, broadcast the QC proposal
     if sender == leader && sender.validate(&qc_proposal.signature, leaf.commit().as_ref()) {


### PR DESCRIPTION
Removes the genesis hack from the builder.

Do not merge until this is fixed in HotShot.
