### PR TITLE
Fixing the result of a merge mistake

### DIFF
--- a/src/builder_state.rs
+++ b/src/builder_state.rs
@@ -772,13 +772,12 @@ impl<TYPES: NodeType> BuilderProgress<TYPES> for BuilderState<TYPES> {
 
                     // write to global state as well
                     // only write if the entry does not exist
-                    if self
+                    if !self
                         .global_state
                         .read_arc()
                         .await
                         .block_hash_to_block
-                        .get(&response.builder_hash)
-                        .is_none()
+                        .contains_key(&response.builder_hash)
                     {
                         self.global_state
                             .write_arc()


### PR DESCRIPTION
There's also a clippy fix, for some added code that, maybe, could improve rwlock behavior.