### PR TITLE
Performance Improvement Changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3135,7 +3135,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-builder-core"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3163,6 +3163,7 @@ dependencies = [
 [[package]]
 name = "hotshot-events-service"
 version = "0.1.12"
+source = "git+https://github.com/EspressoSystems/hotshot-events-service.git?branch=main#414397e382b24d938cdbe0e41f28add043e58699"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -3571,7 +3572,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core 0.52.0",
+ "windows-core",
 ]
 
 [[package]]
@@ -8765,7 +8766,7 @@ version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca229916c5ee38c2f2bc1e9d8f04df975b4bd93f9955dc69fabb5d91270045c9"
 dependencies = [
- "windows-core 0.51.1",
+ "windows-core",
  "windows-targets 0.48.5",
 ]
 
@@ -8776,15 +8777,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
 dependencies = [
  "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
- "windows-targets 0.52.5",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3163,7 +3163,7 @@ dependencies = [
 [[package]]
 name = "hotshot-events-service"
 version = "0.1.12"
-source = "git+https://github.com/EspressoSystems/hotshot-events-service.git?branch=main#414397e382b24d938cdbe0e41f28add043e58699"
+source = "git+https://github.com/EspressoSystems/hotshot-events-service.git?tag=0.1.14#414397e382b24d938cdbe0e41f28add043e58699"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,6 @@ version = "0.1.12"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[patch."https://github.com/EspressoSystems/hotshot-events-service"]
-hotshot-events-service = { path = "../hotshot-events-service" }
-
 [dependencies]
 async-broadcast = "0.7.0"
 async-compatibility-layer = { version = "1.1", default-features = false, features = [
@@ -20,7 +17,7 @@ committable = "0.2"
 futures = "0.3"
 hotshot = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.44" }
 hotshot-builder-api = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.44" }
-hotshot-events-service = { git = "https://github.com/EspressoSystems/hotshot-events-service.git", tag = "0.1.13" }
+hotshot-events-service = { git = "https://github.com/EspressoSystems/hotshot-events-service.git", branch = "main" }
 hotshot-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.44" }
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ committable = "0.2"
 futures = "0.3"
 hotshot = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.44" }
 hotshot-builder-api = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.44" }
-hotshot-events-service = { git = "https://github.com/EspressoSystems/hotshot-events-service.git", branch = "main" }
+hotshot-events-service = { git = "https://github.com/EspressoSystems/hotshot-events-service.git", tag = "0.1.14" }
 hotshot-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.44" }
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.10"

--- a/src/builder_state.rs
+++ b/src/builder_state.rs
@@ -639,8 +639,8 @@ impl<TYPES: NodeType> BuilderProgress<TYPES> for BuilderState<TYPES> {
     #[tracing::instrument(skip_all, name = "build block",
                                     fields(builder_built_from_proposed_block = %self.built_from_proposed_block))]
     async fn build_block(&mut self, matching_vid: VidCommitment) -> Option<BuildBlockInfo<TYPES>> {
-        // provide atleast 1 txn inside the block process the transactions
-        // ideally this should be a threshold should a configurable value, if it gets non-zero before time return, otherwise return after timeout
+        // try to provide atleast one txn inside the block, ideally this should be a threshold through configurable value,
+        // if it gets non-zero before timeout return, otherwise return after timeout
         if self.timestamp_to_tx.is_empty() {
             let timeout_after = Instant::now() + self.maximize_txn_capture_timeout;
             while let Ok(tx) = self.tx_receiver.try_recv() {

--- a/src/builder_state.rs
+++ b/src/builder_state.rs
@@ -1,6 +1,5 @@
 use hotshot_types::{
     data::{DAProposal, Leaf, QuorumProposal},
-    event::LeafChain,
     message::Proposal,
     traits::block_contents::{BlockHeader, BlockPayload},
     traits::{
@@ -51,7 +50,7 @@ pub struct TransactionMessage<TYPES: NodeType> {
 /// Decide Message to be put on the decide channel
 #[derive(Clone, Debug)]
 pub struct DecideMessage<TYPES: NodeType> {
-    pub leaf_chain: Arc<LeafChain<TYPES>>,
+    pub latest_decide_view_number: TYPES::Time,
     pub block_size: Option<u64>,
 }
 /// DA Proposal Message to be put on the da proposal channel
@@ -493,11 +492,8 @@ impl<TYPES: NodeType> BuilderProgress<TYPES> for BuilderState<TYPES> {
         // special clone already launched the clone, then exit
         // if you haven't launched the clone, then you don't exit, you need atleast one clone to function properly
         // the special value can be 0 itself, or a view number 0 is also right answer
-        let leaf_chain = decide_msg.leaf_chain;
         let _block_size = decide_msg.block_size;
-        let _latest_decide_parent_commitment = leaf_chain[0].leaf.get_parent_commitment();
-        let _latest_decide_commitment = leaf_chain[0].leaf.commit();
-        let latest_leaf_view_number = leaf_chain[0].leaf.get_view_number();
+        let latest_leaf_view_number = decide_msg.latest_decide_view_number;
         let latest_leaf_view_number_as_i64 = latest_leaf_view_number.get_u64() as i64;
 
         // Garbage collection

--- a/src/builder_state.rs
+++ b/src/builder_state.rs
@@ -811,17 +811,17 @@ impl<TYPES: NodeType> BuilderProgress<TYPES> for BuilderState<TYPES> {
                     }
                 }
 
-                // read all the available requests from the channel and process them
-                while let Ok(req) = self.req_receiver.try_recv() {
-                    tracing::debug!(
-                        "Received request msg in builder {:?}: {:?}",
-                        self.built_from_proposed_block.view_number,
-                        req
-                    );
-                    if let MessageType::RequestMessage(req) = req {
-                        self.process_block_request(req).await;
-                    }
-                }
+                // // read all the available requests from the channel and process them
+                // while let Ok(req) = self.req_receiver.try_recv() {
+                //     tracing::debug!(
+                //         "Received request msg in builder {:?}: {:?}",
+                //         self.built_from_proposed_block.view_number,
+                //         req
+                //     );
+                //     if let MessageType::RequestMessage(req) = req {
+                //         self.process_block_request(req).await;
+                //     }
+                // }
 
                 futures::select! {
                     req = self.req_receiver.next() => {

--- a/src/builder_state.rs
+++ b/src/builder_state.rs
@@ -474,7 +474,6 @@ impl<TYPES: NodeType> BuilderProgress<TYPES> for BuilderState<TYPES> {
         let _latest_decide_parent_commitment = leaf_chain[0].leaf.get_parent_commitment();
         let _latest_decide_commitment = leaf_chain[0].leaf.commit();
         let latest_leaf_view_number = leaf_chain[0].leaf.get_view_number();
-        let built_from_view_as_i64 = self.built_from_proposed_block.view_number.get_u64() as i64;
         let latest_leaf_view_number_as_i64 = latest_leaf_view_number.get_u64() as i64;
 
         // Garbage collection
@@ -547,9 +546,7 @@ impl<TYPES: NodeType> BuilderProgress<TYPES> for BuilderState<TYPES> {
                 // Not return from here, needs leaf cleaning also
                 //return Some(Status::ShouldContinue);
             }
-        } else if built_from_view_as_i64
-            <= (latest_leaf_view_number_as_i64 - self.buffer_view_num_count as i64)
-        {
+        } else if self.built_from_proposed_block.view_number <= latest_leaf_view_number {
             tracing::info!("Task view is less than or equal to the currently decided leaf view {:?}; exiting builder state for view {:?}", latest_leaf_view_number.get_u64(), self.built_from_proposed_block.view_number.get_u64());
             // convert leaf commitments into buildercommiments
             // remove the handles from the global state
@@ -562,10 +559,6 @@ impl<TYPES: NodeType> BuilderProgress<TYPES> for BuilderState<TYPES> {
 
             // clear out the local_block_hash_to_block
             return Some(Status::ShouldExit);
-        } else if built_from_view_as_i64
-            > (latest_leaf_view_number_as_i64 - self.buffer_view_num_count as i64)
-        {
-            return Some(Status::ShouldContinue);
         }
 
         // go through all the leaves

--- a/src/service.rs
+++ b/src/service.rs
@@ -288,10 +288,7 @@ where
             });
         }
 
-        tracing::info!(
-            "Requesting available blocks for parent {:?}",
-            req_msg.requested_vid_commitment
-        );
+        tracing::info!("Requesting available blocks for parent {:?}", for_parent);
 
         let mut bootstrapped_state_build_block = false;
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -192,6 +192,8 @@ impl<Types: NodeType> GlobalState<Types> {
             tracing::debug!("]\n");
         }
 
+        tracing::debug!("GC for view {:?} scheduled", on_decide_view);
+
         self.view_to_cleanup_targets
             .retain(|view_num, (vids, block_hashes)| {
                 if view_num > &on_decide_view {

--- a/src/service.rs
+++ b/src/service.rs
@@ -172,7 +172,6 @@ impl<Types: NodeType> GlobalState<Types> {
         }
         {
             let cleanup_after_view = on_decide_view + self.buffer_view_num_count;
-            tracing::debug!("Removing builder commitments: [");
 
             let edit = self
                 .view_to_cleanup_targets
@@ -189,10 +188,9 @@ impl<Types: NodeType> GlobalState<Types> {
                     cleanup_after_view
                 );
             }
-            tracing::debug!("]\n");
         }
 
-        tracing::debug!("GC for view {:?} scheduled", on_decide_view);
+        tracing::debug!("GC for scheduled view {:?}", on_decide_view);
 
         self.view_to_cleanup_targets
             .retain(|view_num, (vids, block_hashes)| {
@@ -424,6 +422,7 @@ where
             }
         }
     }
+
     async fn claim_block(
         &self,
         block_hash: &BuilderCommitment,
@@ -473,6 +472,7 @@ where
             })
         }
     }
+
     async fn claim_block_header_input(
         &self,
         block_hash: &BuilderCommitment,

--- a/src/service.rs
+++ b/src/service.rs
@@ -288,6 +288,11 @@ where
             });
         }
 
+        tracing::info!(
+            "Requesting available blocks for parent {:?}",
+            req_msg.requested_vid_commitment
+        );
+
         let mut bootstrapped_state_build_block = false;
 
         // check in the local spawned builder states, if it doesn't exist it means it cound be two cases
@@ -318,11 +323,6 @@ where
             Ok(just_return_with_this.unwrap().clone())
         } else {
             let timeout_after = Instant::now() + self.max_api_waiting_time;
-
-            tracing::info!(
-                "Requesting available blocks for parent {:?}",
-                req_msg.requested_vid_commitment
-            );
 
             // broadcast the request to the builder states
             self.global_state

--- a/src/service.rs
+++ b/src/service.rs
@@ -171,14 +171,14 @@ impl<Types: NodeType> GlobalState<Types> {
             }
         }
         {
-            let cleanup_after_view = on_decide_view + self.buffer_view_num_count.into();
+            let cleanup_after_view = on_decide_view + self.buffer_view_num_count;
             tracing::debug!("Removing builder commitments: [");
 
             let edit = self
                 .view_to_cleanup_targets
                 .entry(cleanup_after_view)
                 .or_insert((Default::default(), Default::default()));
-            edit.0.push(builder_vid_commitment.clone());
+            edit.0.push(*builder_vid_commitment);
 
             for (view_num, block_hash) in block_hashes {
                 edit.1.push(block_hash.clone());
@@ -195,7 +195,7 @@ impl<Types: NodeType> GlobalState<Types> {
         self.view_to_cleanup_targets
             .retain(|view_num, (vids, block_hashes)| {
                 if view_num > &on_decide_view {
-                    return true;
+                    true
                 } else {
                     // go through the vids and remove from the builder_state_to_last_built_block
                     // and block_hashes and remove the block_hashes from the block_hash_to_block
@@ -205,7 +205,7 @@ impl<Types: NodeType> GlobalState<Types> {
                     block_hashes.iter().for_each(|block_hash| {
                         self.block_hash_to_block.remove(block_hash);
                     });
-                    return false;
+                    false
                 }
             });
     }

--- a/src/service.rs
+++ b/src/service.rs
@@ -18,7 +18,7 @@ use hotshot_types::{
         block_contents::BlockPayload,
         consensus_api::ConsensusApi,
         election::Membership,
-        node_implementation::{ConsensusTime, NodeType},
+        node_implementation::NodeType,
         signature_key::{BuilderSignatureKey, SignatureKey},
     },
     utils::BuilderCommitment,
@@ -48,7 +48,7 @@ use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     ops::Deref,
 };
 use std::{fmt::Display, time::Instant};
@@ -76,6 +76,10 @@ pub struct GlobalState<Types: NodeType> {
     // if the req channel times out during get_avaialble_blocks
     pub builder_state_to_last_built_block: HashMap<VidCommitment, ResponseMessage>,
 
+    // scheduled GC by view number
+    pub view_to_cleanup_targets:
+        BTreeMap<Types::Time, (Vec<VidCommitment>, Vec<BuilderCommitment>)>,
+
     // sending a request from the hotshot to the builder states
     pub request_sender: BroadcastSender<MessageType<Types>>,
 
@@ -93,7 +97,7 @@ pub struct GlobalState<Types: NodeType> {
     pub last_garbage_collected_view_num: Types::Time,
 
     /// number of view to buffer before garbage collect
-    pub buffer_view_num_count: usize,
+    pub buffer_view_num_count: u64,
 }
 
 impl<Types: NodeType> GlobalState<Types> {
@@ -106,13 +110,14 @@ impl<Types: NodeType> GlobalState<Types> {
         bootstrapped_builder_state_id: VidCommitment,
         bootstrapped_view_num: Types::Time,
         last_garbage_collected_view_num: Types::Time,
-        buffer_view_num_count: usize,
+        buffer_view_num_count: u64,
     ) -> Self {
         let mut spawned_builder_states = HashMap::new();
         spawned_builder_states.insert(bootstrapped_builder_state_id, bootstrapped_view_num);
         GlobalState {
             block_hash_to_block: Default::default(),
             spawned_builder_states,
+            view_to_cleanup_targets: Default::default(),
             request_sender,
             response_receiver,
             tx_sender,
@@ -152,58 +157,57 @@ impl<Types: NodeType> GlobalState<Types> {
         &mut self,
         builder_vid_commitment: &VidCommitment,
         block_hashes: HashSet<(Types::Time, BuilderCommitment)>,
+        on_decide_view: Types::Time,
         bootstrap: bool,
     ) {
-        // GC strategy: remove the builder state related stuff if
-        // builder states views are less than highest view seen - buffer_view_num_count
-
-        let max_view_num_in_block_hashed = block_hashes
-            .iter()
-            .map(|(view_num, _)| view_num)
-            .max()
-            .unwrap_or(&self.last_garbage_collected_view_num);
-
-        let garbage_collected_till_view_num = std::cmp::max(
-            max_view_num_in_block_hashed.get_u64() as i64 - self.buffer_view_num_count as i64,
-            self.last_garbage_collected_view_num.get_u64() as i64,
-        );
-
-        let garbage_collected_till_view_num = <<Types as NodeType>::Time as ConsensusTime>::new(
-            garbage_collected_till_view_num as u64,
-        );
-
-        let builder_state_view_num = self.spawned_builder_states.get(builder_vid_commitment);
-
-        if builder_state_view_num.is_some()
-            && builder_state_view_num.unwrap() <= &garbage_collected_till_view_num
+        // remove the builder commitment from the spawned builder states
+        if !bootstrap {
+            let view_num = self.spawned_builder_states.remove(builder_vid_commitment);
+            if view_num.is_some() {
+                tracing::info!(
+                    "Removing handles for builder view num {:?}",
+                    view_num.unwrap()
+                );
+            }
+        }
         {
-            tracing::debug!(
-                "Removing builder commitments for view {:?} ",
-                builder_state_view_num.unwrap()
-            );
+            let cleanup_after_view = on_decide_view + self.buffer_view_num_count.into();
+            tracing::debug!("Removing builder commitments: [");
+
+            let edit = self
+                .view_to_cleanup_targets
+                .entry(cleanup_after_view)
+                .or_insert((Default::default(), Default::default()));
+            edit.0.push(builder_vid_commitment.clone());
+
             for (view_num, block_hash) in block_hashes {
-                self.block_hash_to_block.remove(&block_hash);
-                tracing::debug!("GC view_num {:?} block_hash {:?},", view_num, block_hash);
+                edit.1.push(block_hash.clone());
+                tracing::debug!(
+                    "GC view_num {:?}: block_hash {:?}, deferred to view {:?} ",
+                    view_num,
+                    block_hash,
+                    cleanup_after_view
+                );
             }
             tracing::debug!("]\n");
         }
 
-        if !bootstrap {
-            self.spawned_builder_states.retain(
-                |_builder_state_vid_commitment, builder_state_view_num| {
-                    *builder_state_view_num >= garbage_collected_till_view_num
-                },
-            );
-            self.builder_state_to_last_built_block.retain(
-                |builder_state_vid_commitment, _last_built_block| {
-                    self.spawned_builder_states
-                        .contains_key(builder_state_vid_commitment)
-                },
-            );
-        }
-
-        // update the last garbage collected view number
-        self.last_garbage_collected_view_num = garbage_collected_till_view_num;
+        self.view_to_cleanup_targets
+            .retain(|view_num, (vids, block_hashes)| {
+                if view_num > &on_decide_view {
+                    return true;
+                } else {
+                    // go through the vids and remove from the builder_state_to_last_built_block
+                    // and block_hashes and remove the block_hashes from the block_hash_to_block
+                    vids.iter().for_each(|vid| {
+                        self.spawned_builder_states.remove(vid);
+                    });
+                    block_hashes.iter().for_each(|block_hash| {
+                        self.block_hash_to_block.remove(block_hash);
+                    });
+                    return false;
+                }
+            });
     }
 
     // private mempool submit txn
@@ -278,86 +282,102 @@ where
     ) -> Result<Vec<AvailableBlockInfo<Types>>, BuildError> {
         // verify the signature
         if !sender.validate(signature, for_parent.as_ref()) {
+            tracing::error!("Signature validation failed in get_available_blocks");
             return Err(BuildError::Error {
                 message: "Signature validation failed in get_available_blocks".to_string(),
             });
         }
 
         let mut bootstrapped_state_build_block = false;
-        // check in the local spawned builder states, if it doesn't exist, and then let bootstrapped build a block for it
-        if !self
-            .global_state
-            .read_arc()
-            .await
-            .spawned_builder_states
-            .contains_key(for_parent)
-        {
-            bootstrapped_state_build_block = true;
-        }
+
+        // check in the local spawned builder states, if it doesn't exist it means it cound be two cases
+        // it has been sent to garbed collected, or never exists, in this let bootstrapped build a block for it
+        let just_return_with_this = {
+            let global_state = self.global_state.read_arc().await;
+            if !global_state.spawned_builder_states.contains_key(for_parent) {
+                if let Some(cached) = global_state
+                    .builder_state_to_last_built_block
+                    .get(for_parent)
+                {
+                    Some(cached.clone())
+                } else {
+                    bootstrapped_state_build_block = true;
+                    None
+                }
+            } else {
+                None
+            }
+        };
 
         let req_msg = RequestMessage {
             requested_vid_commitment: (*for_parent),
             bootstrap_build_block: bootstrapped_state_build_block,
         };
 
-        tracing::info!(
-            "Requesting available blocks for parent {:?}",
-            req_msg.requested_vid_commitment
-        );
+        let response_received = if just_return_with_this.is_some() {
+            Ok(just_return_with_this.unwrap().clone())
+        } else {
+            let timeout_after = Instant::now() + self.max_api_waiting_time;
 
-        self.global_state
-            .read_arc()
-            .await
-            .request_sender
-            .broadcast(MessageType::RequestMessage(req_msg.clone()))
-            .await
-            .unwrap();
+            tracing::info!(
+                "Requesting available blocks for parent {:?}",
+                req_msg.requested_vid_commitment
+            );
 
-        tracing::debug!(
-            "Waiting for response for parent {:?}",
-            req_msg.requested_vid_commitment
-        );
-
-        let timeout_after = Instant::now() + self.max_api_waiting_time;
-        let response_received = loop {
-            let recv_attempt = self
-                .global_state
+            // broadcast the request to the builder states
+            self.global_state
                 .read_arc()
                 .await
-                .response_receiver
-                .try_recv();
-            if recv_attempt.is_ok() {
-                break recv_attempt.map_err(|_| BuildError::Missing);
-            } else {
-                let e = recv_attempt.unwrap_err();
-                if e.is_empty() {
-                    if Instant::now() >= timeout_after {
-                        // lookup into the builder_state_to_last_built_block, if it contains the result, return that otherwise return error
-                        if let Some(last_built_block) = self
-                            .global_state
-                            .read_arc()
-                            .await
-                            .builder_state_to_last_built_block
-                            .get(for_parent)
-                        {
-                            tracing::info!(
-                                "Returning last built block for parent {:?}",
-                                req_msg.requested_vid_commitment
-                            );
-                            break Ok(last_built_block.clone());
+                .request_sender
+                .broadcast(MessageType::RequestMessage(req_msg.clone()))
+                .await
+                .unwrap();
+
+            tracing::debug!(
+                "Waiting for response for parent {:?}",
+                req_msg.requested_vid_commitment
+            );
+
+            loop {
+                let recv_attempt = self
+                    .global_state
+                    .read_arc()
+                    .await
+                    .response_receiver
+                    .try_recv();
+                if recv_attempt.is_ok() {
+                    break recv_attempt.map_err(|_| BuildError::Missing);
+                } else {
+                    let e = recv_attempt.unwrap_err();
+                    if e.is_empty() {
+                        if Instant::now() >= timeout_after {
+                            // lookup into the builder_state_to_last_built_block, if it contains the result, return that otherwise return error
+                            if let Some(last_built_block) = self
+                                .global_state
+                                .read_arc()
+                                .await
+                                .builder_state_to_last_built_block
+                                .get(for_parent)
+                            {
+                                tracing::info!(
+                                    "Returning last built block for parent {:?}",
+                                    req_msg.requested_vid_commitment
+                                );
+                                break Ok(last_built_block.clone());
+                            }
+                            tracing::warn!(%e, "Couldn't get available blocks in time for parent {:?}",  req_msg.requested_vid_commitment);
+                            break Err(BuildError::Error {
+                                message: "No blocks available".to_string(),
+                            });
                         }
-                        tracing::error!(%e, "Couldn't get available blocks in time for parent {:?}",  req_msg.requested_vid_commitment);
+                        async_compatibility_layer::art::async_yield_now().await;
+                        continue;
+                    } else {
+                        tracing::error!(%e, "Channel closed while getting available blocks for parent {:?}", req_msg.requested_vid_commitment);
                         break Err(BuildError::Error {
-                            message: "No blocks available".to_string(),
+                            message: "channel unexpectedly closed".to_string(),
                         });
                     }
-                    async_compatibility_layer::art::async_yield_now().await;
-                    continue;
-                } else {
-                    tracing::error!(%e, "Channel closed while getting available blocks for parent {:?}", req_msg.requested_vid_commitment);
-                    break Err(BuildError::Error {
-                        message: "channel unexpectedly closed".to_string(),
-                    });
                 }
             }
         };
@@ -393,7 +413,13 @@ where
             }
 
             // We failed to get available blocks
-            Err(e) => Err(e),
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to get available blocks for parent {:?}",
+                    req_msg.requested_vid_commitment
+                );
+                Err(e)
+            }
         }
     }
     async fn claim_block(
@@ -439,7 +465,7 @@ where
             tracing::info!("Sending Claim Block data for block hash: {:?}", block_hash);
             Ok(block_data)
         } else {
-            tracing::error!("Claim Block not found");
+            tracing::warn!("Claim Block not found");
             Err(BuildError::Error {
                 message: "Block data not found".to_string(),
             })
@@ -496,7 +522,7 @@ where
             );
             Ok(response)
         } else {
-            tracing::error!("Claim Block Header Input not found");
+            tracing::warn!("Claim Block Header Input not found");
             Err(BuildError::Error {
                 message: "Block Header not found".to_string(),
             })

--- a/src/testing/basic_test.rs
+++ b/src/testing/basic_test.rs
@@ -113,6 +113,8 @@ mod tests {
             TestInstanceState {},
             vid_commitment(&[], 8),
             ViewNumber::new(0),
+            ViewNumber::new(0),
+            10,
         );
 
         // to store all the sent messages

--- a/src/testing/basic_test.rs
+++ b/src/testing/basic_test.rs
@@ -48,6 +48,7 @@ mod tests {
     use committable::{Commitment, CommitmentBoundsArkless, Committable};
     use sha2::{Digest, Sha256};
     use std::sync::Arc;
+    use std::time::Duration;
 
     use serde::{Deserialize, Serialize};
     /// This test simulates multiple builder states receiving messages from the channels and processing them
@@ -345,6 +346,7 @@ mod tests {
                 NonZeroUsize::new(TEST_NUM_NODES_IN_VID_COMPUTATION).unwrap(),
                 ViewNumber::new(0),
                 10,
+                Duration::from_millis(10),
             );
 
             //builder_state.event_loop().await;


### PR DESCRIPTION
- Removes the GC from decide event to global state. It ensures that old builder states don't keep on listening onto channels, and exit as soon as they see corresponding latest decide view.
- Simplifies the `handle_decide_event`, making it depend on latest_decide_view_number, enabling pruning of decide event.
- The tx store GC for bootstrapping gets done when it spawns a builder state.
- Enables maximizing txn collection before building a block with the help of timeout.