### PR TITLE
enable batch processing

### DIFF
--- a/src/builder_state.rs
+++ b/src/builder_state.rs
@@ -232,7 +232,6 @@ impl<TYPES: NodeType> BuilderProgress<TYPES> for BuilderState<TYPES> {
         txns.iter().for_each(|tx| {
             let tx_hash = tx.commit();
             tracing::debug!("Transaction hash: {:?}", tx_hash);
-            
             if self.tx_hash_to_available_txns.contains_key(&tx_hash)
                 || self.included_txns.contains(&tx_hash)
             {
@@ -282,7 +281,6 @@ impl<TYPES: NodeType> BuilderProgress<TYPES> for BuilderState<TYPES> {
                     .insert(tx_hash, (tx_timestamp, tx.clone(), TransactionSource::HotShot));
             }
         });
-    
     }
 
     /// processing the DA proposal

--- a/src/testing/basic_test.rs
+++ b/src/testing/basic_test.rs
@@ -134,7 +134,7 @@ mod tests {
             let encoded_transactions = TestTransaction::encode(&[tx.clone()]).unwrap();
 
             let stx_msg = TransactionMessage::<TestTypes> {
-                tx: tx.clone(),
+                txns: vec![tx.clone()],
                 tx_type: TransactionSource::HotShot,
             };
 


### PR DESCRIPTION
- Currently inadvertently builder was processing each txn separately, it enables the builder to process the whole submitted txn batch at a time. 