### PR TITLE
Guarantee that exactly one BlockBuilder handles each request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1297,7 +1297,7 @@ checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
 [[package]]
 name = "cdn-broker"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.2.4#31a2f7f97ba32f8b2894fae4e7d3e5c484eb3675"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.2.5#c4208513280bd9beeb151e20e44179f2d3cc690a"
 dependencies = [
  "async-std",
  "cdn-proto",
@@ -1319,7 +1319,7 @@ dependencies = [
 [[package]]
 name = "cdn-client"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.2.4#31a2f7f97ba32f8b2894fae4e7d3e5c484eb3675"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.2.5#c4208513280bd9beeb151e20e44179f2d3cc690a"
 dependencies = [
  "async-std",
  "cdn-proto",
@@ -1334,7 +1334,7 @@ dependencies = [
 [[package]]
 name = "cdn-marshal"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.2.4#31a2f7f97ba32f8b2894fae4e7d3e5c484eb3675"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.2.5#c4208513280bd9beeb151e20e44179f2d3cc690a"
 dependencies = [
  "async-std",
  "cdn-proto",
@@ -1348,7 +1348,7 @@ dependencies = [
 [[package]]
 name = "cdn-proto"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.2.4#31a2f7f97ba32f8b2894fae4e7d3e5c484eb3675"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.2.5#c4208513280bd9beeb151e20e44179f2d3cc690a"
 dependencies = [
  "anyhow",
  "ark-serialize",
@@ -3072,6 +3072,7 @@ dependencies = [
 [[package]]
 name = "hotshot"
 version = "0.5.43"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=main#485d6f222b06277623e0f9ea0032587d819f085e"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3116,6 +3117,7 @@ dependencies = [
 [[package]]
 name = "hotshot-builder-api"
 version = "0.1.7"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=main#485d6f222b06277623e0f9ea0032587d819f085e"
 dependencies = [
  "async-trait",
  "clap",
@@ -3161,6 +3163,7 @@ dependencies = [
 [[package]]
 name = "hotshot-events-service"
 version = "0.1.15"
+source = "git+https://github.com/EspressoSystems/hotshot-events-service.git?branch=nfy/do_not_merge/track_hotshot_main#c9f19e92db0428b4e624e5fde29f2fdb15f6a710"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -3185,6 +3188,7 @@ dependencies = [
 [[package]]
 name = "hotshot-example-types"
 version = "0.5.43"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=main#485d6f222b06277623e0f9ea0032587d819f085e"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3214,6 +3218,7 @@ dependencies = [
 [[package]]
 name = "hotshot-orchestrator"
 version = "0.5.43"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=main#485d6f222b06277623e0f9ea0032587d819f085e"
 dependencies = [
  "anyhow",
  "async-compatibility-layer",
@@ -3242,6 +3247,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task"
 version = "0.5.43"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=main#485d6f222b06277623e0f9ea0032587d819f085e"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -3254,6 +3260,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task-impls"
 version = "0.5.43"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=main#485d6f222b06277623e0f9ea0032587d819f085e"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3286,6 +3293,7 @@ dependencies = [
 [[package]]
 name = "hotshot-types"
 version = "0.1.11"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=main#485d6f222b06277623e0f9ea0032587d819f085e"
 dependencies = [
  "anyhow",
  "ark-bls12-381",
@@ -3337,6 +3345,7 @@ dependencies = [
 [[package]]
 name = "hotshot-web-server"
 version = "0.5.43"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=main#485d6f222b06277623e0f9ea0032587d819f085e"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",
@@ -4407,6 +4416,7 @@ dependencies = [
 [[package]]
 name = "libp2p-networking"
 version = "0.5.43"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=main#485d6f222b06277623e0f9ea0032587d819f085e"
 dependencies = [
  "anyhow",
  "async-compatibility-layer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-broadcast = "0.7.0"
+async-broadcast = "0.7"
 async-compatibility-layer = { version = "1.1", default-features = false, features = [
     "logging-utils",
 ] }
@@ -15,10 +15,10 @@ async-trait = "0.1"
 clap = { version = "4.4", features = ["derive", "env"] }
 committable = "0.2"
 futures = "0.3"
-hotshot = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.46" }
-hotshot-builder-api = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.46" }
-hotshot-events-service = { git = "https://github.com/EspressoSystems/hotshot-events-service.git", tag = "0.1.16" }
-hotshot-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.46" }
+hotshot = { git = "https://github.com/EspressoSystems/HotShot.git", branch = "main" }
+hotshot-builder-api = { git = "https://github.com/EspressoSystems/HotShot.git", branch = "main" }
+hotshot-events-service = { git = "https://github.com/EspressoSystems/hotshot-events-service.git", branch = "nfy/do_not_merge/track_hotshot_main" }
+hotshot-types = { git = "https://github.com/EspressoSystems/HotShot.git", branch = "main" }
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.10"
 snafu = "0.8"
@@ -29,15 +29,4 @@ tracing = "0.1"
 vbs = "0.1"
 
 [dev-dependencies]
-hotshot-example-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.46" }
-
-
-[patch.'https://github.com/EspressoSystems/hotshot']
-hotshot-types = { path = "../HotShot/crates/types" }
-hotshot-example-types = { path = "../HotShot/crates/example-types" }
-hotshot-builder-api = { path = "../HotShot/crates/builder-api" }
-hotshot = { path = "../HotShot/crates/hotshot" }
-
-
-[patch.'https://github.com/EspressoSystems/hotshot-events-service']
-hotshot-events-service = { path = "../hotshot-events-service" }
+hotshot-example-types = { git = "https://github.com/EspressoSystems/HotShot.git", branch = "main" }

--- a/src/builder_state.rs
+++ b/src/builder_state.rs
@@ -979,7 +979,6 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
             builder_commitments: self.builder_commitments.clone(),
             total_nodes: self.total_nodes,
             bootstrap_view_number: self.bootstrap_view_number,
-            spawned_clones_list: self.spawned_clones_list.clone(),
             last_bootstrap_garbage_collected_decided_seen_view_num: self
                 .last_bootstrap_garbage_collected_decided_seen_view_num,
             buffer_view_num_count: self.buffer_view_num_count,

--- a/src/builder_state.rs
+++ b/src/builder_state.rs
@@ -15,7 +15,9 @@ use hotshot_types::{
 use committable::{Commitment, Committable};
 
 use crate::service::GlobalState;
+use async_broadcast::broadcast;
 use async_broadcast::Receiver as BroadcastReceiver;
+use async_broadcast::Sender as BroadcastSender;
 use async_compatibility_layer::art::async_sleep;
 use async_compatibility_layer::channel::{unbounded, UnboundedSender};
 use async_compatibility_layer::{art::async_spawn, channel::UnboundedReceiver};
@@ -23,6 +25,7 @@ use async_lock::RwLock;
 use async_trait::async_trait;
 use core::panic;
 use futures::StreamExt;
+
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -69,11 +72,12 @@ pub struct QCMessage<TYPES: NodeType> {
     pub sender: TYPES::SignatureKey,
 }
 /// Request Message to be put on the request channel
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct RequestMessage {
     pub requested_vid_commitment: VidCommitment,
     pub requested_view_number: u64,
     pub bootstrap_build_block: bool,
+    pub response_channel: UnboundedSender<ResponseMessage>,
 }
 /// Response Message to be put on the response channel
 #[derive(Debug)]
@@ -115,7 +119,7 @@ impl<TYPES: NodeType> std::fmt::Display for BuiltFromProposedBlock<TYPES> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct BuilderState<TYPES: NodeType> {
     /// timestamp to tx hash, used for ordering for the transactions
     pub timestamp_to_tx: BTreeMap<TxTimeStamp, Commitment<TYPES::Transaction>>,
@@ -157,9 +161,6 @@ pub struct BuilderState<TYPES: NodeType> {
 
     /// global state handle, defined in the service.rs
     pub global_state: Arc<RwLock<GlobalState<TYPES>>>,
-
-    /// response sender
-    pub response_sender: UnboundedSender<ResponseMessage>,
 
     /// total nodes required for the VID computation as part of block header input response
     pub total_nodes: NonZeroUsize,
@@ -213,6 +214,7 @@ pub trait BuilderProgress<TYPES: NodeType> {
         da_proposal: DAProposal<TYPES>,
         quorum_proposal: QuorumProposal<TYPES>,
         leader: TYPES::SignatureKey,
+        req_sender: BroadcastSender<MessageType<TYPES>>,
     );
 
     /// build a block
@@ -394,8 +396,9 @@ impl<TYPES: NodeType> BuilderProgress<TYPES> for BuilderState<TYPES> {
                         self.tx_hash_to_available_txns.clear();
                         self.timestamp_to_tx.clear();
                     }
-                    self.clone()
-                        .spawn_clone(da_proposal_data, qc_proposal_data, sender)
+                    let (req_sender, req_receiver) = broadcast(self.req_receiver.capacity());
+                    self.clone_with_receiver(req_receiver)
+                        .spawn_clone(da_proposal_data, qc_proposal_data, sender, req_sender)
                         .await;
                 } else {
                     tracing::debug!("Not spawning a clone despite matching DA and QC payload commitments, as they corresponds to different view numbers");
@@ -488,8 +491,9 @@ impl<TYPES: NodeType> BuilderProgress<TYPES> for BuilderState<TYPES> {
                         self.tx_hash_to_available_txns.clear();
                         self.timestamp_to_tx.clear();
                     }
-                    self.clone()
-                        .spawn_clone(da_proposal_data, qc_proposal_data, sender)
+                    let (req_sender, req_receiver) = broadcast(self.req_receiver.capacity());
+                    self.clone_with_receiver(req_receiver)
+                        .spawn_clone(da_proposal_data, qc_proposal_data, sender, req_sender)
                         .await;
                 } else {
                     tracing::debug!("Not spawning a clone despite matching DA and QC payload commitments, as they corresponds to different view numbers");
@@ -610,6 +614,7 @@ impl<TYPES: NodeType> BuilderProgress<TYPES> for BuilderState<TYPES> {
         da_proposal: DAProposal<TYPES>,
         quorum_proposal: QuorumProposal<TYPES>,
         _leader: TYPES::SignatureKey,
+        req_sender: BroadcastSender<MessageType<TYPES>>,
     ) {
         self.built_from_proposed_block.view_number = quorum_proposal.view_number;
         self.built_from_proposed_block.vid_commitment =
@@ -640,10 +645,13 @@ impl<TYPES: NodeType> BuilderProgress<TYPES> for BuilderState<TYPES> {
             .write_arc()
             .await
             .spawned_builder_states
-            .insert((
-                self.built_from_proposed_block.vid_commitment,
-                self.built_from_proposed_block.view_number,
-            ));
+            .insert(
+                (
+                    self.built_from_proposed_block.vid_commitment,
+                    self.built_from_proposed_block.view_number,
+                ),
+                req_sender,
+            );
 
         self.event_loop();
     }
@@ -660,34 +668,33 @@ impl<TYPES: NodeType> BuilderProgress<TYPES> for BuilderState<TYPES> {
         // if it gets non-zero before timeout return, otherwise return after timeout
         if self.timestamp_to_tx.is_empty() {
             let timeout_after = Instant::now() + self.maximize_txn_capture_timeout;
+            let sleep_interval = self.maximize_txn_capture_timeout / 10;
             loop {
-                if let Ok(tx) = self.tx_receiver.try_recv() {
-                    if let MessageType::TransactionMessage(rtx_msg) = tx {
-                        tracing::debug!(
-                            "Received ({:?}) txns msg in builder {:?}",
-                            rtx_msg.txns.len(),
-                            self.built_from_proposed_block,
-                        );
-                        if rtx_msg.tx_type == TransactionSource::HotShot {
-                            self.process_hotshot_transaction(rtx_msg.txns);
-                        } else {
-                            self.process_external_transaction(rtx_msg.txns);
-                        }
-                        tracing::debug!("tx map size: {}", self.tx_hash_to_available_txns.len());
+                if let Ok(MessageType::TransactionMessage(rtx_msg)) = self.tx_receiver.try_recv() {
+                    tracing::debug!(
+                        "Received ({:?}) txns msg in builder {:?}",
+                        rtx_msg.txns.len(),
+                        self.built_from_proposed_block,
+                    );
+                    if rtx_msg.tx_type == TransactionSource::HotShot {
+                        self.process_hotshot_transaction(rtx_msg.txns);
+                    } else {
+                        self.process_external_transaction(rtx_msg.txns);
                     }
+                    tracing::debug!("tx map size: {}", self.tx_hash_to_available_txns.len());
                 }
                 // return if non-zero txns are available
                 if !self.timestamp_to_tx.is_empty() {
                     break;
                 }
-                // if timeout, return
-                if Instant::now() >= timeout_after {
+                // if would timeout before next wake, return
+                if Instant::now() + sleep_interval > timeout_after {
                     break;
                 }
 
-                async_sleep(self.maximize_txn_capture_timeout / 10).await;
+                async_sleep(sleep_interval).await;
             }
-        };
+        }
 
         if let Ok((payload, metadata)) = <TYPES::BlockPayload as BlockPayload>::from_transactions(
             self.timestamp_to_tx.iter().filter_map(|(_ts, tx_hash)| {
@@ -757,14 +764,7 @@ impl<TYPES: NodeType> BuilderProgress<TYPES> for BuilderState<TYPES> {
         if (requested_vid_commitment == self.built_from_proposed_block.vid_commitment
             && requested_view_number == self.built_from_proposed_block.view_number)
             || (self.built_from_proposed_block.view_number.get_u64()
-                == self.bootstrap_view_number.get_u64()
-                && (req.bootstrap_build_block
-                    || !self
-                        .global_state
-                        .read_arc()
-                        .await
-                        .spawned_builder_states
-                        .contains(&(requested_vid_commitment, requested_view_number))))
+                == self.bootstrap_view_number.get_u64())
         {
             tracing::info!(
                 "Request handled by builder with view {:?} for (parent {:?}, view_num: {:?})",
@@ -794,7 +794,7 @@ impl<TYPES: NodeType> BuilderProgress<TYPES> for BuilderState<TYPES> {
                     );
 
                     // ... and finally, send the response
-                    self.response_sender.send(response_msg).await.unwrap();
+                    req.response_channel.send(response_msg).await.unwrap();
 
                     tracing::info!(
                         "Builder {:?} Sent response to the request{:?} with builder hash {:?}",
@@ -846,6 +846,8 @@ impl<TYPES: NodeType> BuilderProgress<TYPES> for BuilderState<TYPES> {
                                         req
                                     );
                                     self.process_block_request(req).await;
+                                } else {
+                                    tracing::warn!("Unexpected message on requests channel: {:?}", req);
                                 }
                             }
                             None => {
@@ -953,7 +955,6 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
         qc_receiver: BroadcastReceiver<MessageType<TYPES>>,
         req_receiver: BroadcastReceiver<MessageType<TYPES>>,
         global_state: Arc<RwLock<GlobalState<TYPES>>>,
-        response_sender: UnboundedSender<ResponseMessage>,
         num_nodes: NonZeroUsize,
         bootstrap_view_number: TYPES::Time,
         buffer_view_num_count: u64,
@@ -974,7 +975,6 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
             da_proposal_payload_commit_to_da_proposal: HashMap::new(),
             quorum_proposal_payload_commit_to_quorum_proposal: HashMap::new(),
             global_state,
-            response_sender,
             builder_commitments: HashSet::new(),
             total_nodes: num_nodes,
             bootstrap_view_number,
@@ -984,6 +984,36 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
             maximize_txn_capture_timeout,
             base_fee,
             instance_state,
+        }
+    }
+    pub fn clone_with_receiver(&self, req_receiver: BroadcastReceiver<MessageType<TYPES>>) -> Self {
+        BuilderState {
+            timestamp_to_tx: self.timestamp_to_tx.clone(),
+            tx_hash_to_available_txns: self.tx_hash_to_available_txns.clone(),
+            included_txns: self.included_txns.clone(),
+            built_from_proposed_block: self.built_from_proposed_block.clone(),
+            tx_receiver: self.tx_receiver.clone(),
+            decide_receiver: self.decide_receiver.clone(),
+            da_proposal_receiver: self.da_proposal_receiver.clone(),
+            qc_receiver: self.qc_receiver.clone(),
+            req_receiver,
+            da_proposal_payload_commit_to_da_proposal: self
+                .da_proposal_payload_commit_to_da_proposal
+                .clone(),
+            quorum_proposal_payload_commit_to_quorum_proposal: self
+                .quorum_proposal_payload_commit_to_quorum_proposal
+                .clone(),
+            global_state: self.global_state.clone(),
+            builder_commitments: self.builder_commitments.clone(),
+            total_nodes: self.total_nodes,
+            bootstrap_view_number: self.bootstrap_view_number,
+            spawned_clones_views_list: self.spawned_clones_views_list.clone(),
+            last_bootstrap_garbage_collected_decided_seen_view_num: self
+                .last_bootstrap_garbage_collected_decided_seen_view_num,
+            buffer_view_num_count: self.buffer_view_num_count,
+            maximize_txn_capture_timeout: self.maximize_txn_capture_timeout,
+            base_fee: self.base_fee,
+            instance_state: self.instance_state.clone(),
         }
     }
 }


### PR DESCRIPTION
Closes #117

### This PR:
Uses dedicated channels for each builder for request, and single-use channels for the response. (Yay, SASE pattern!)

### This PR does not:
- Update the channels to the presumably optimal types;
  -  it keeps `Broadcast{Sender|Receiver}` for the requests because select! cannot achieve compatibility between broadcast-channel's `.next()` and the unbounded channels' `.recv()` for `tokio` or `async-std`, and `async-std`'s `StreamExt` inexplicably makes its `.next()` bind on `Fuse`, in spite of documentation that says otherwise.
  - It keeps `Unbounded{Sender|Receiver}` for the response because there are some things not yet handled in the `async-compatibility-layer` `OneShot{Sender|Receiver}`, and this will do for now. We can revisit if/when we drop `async-std` support.

Note: `Cargo.toml` has modifications that will need to be removed before merging from the target branch to main. They presage a new HotShot tag and corresponding tag on `hotshot-events-service`. The existing target branch has local path `[patch.'..']` sections, which can't be checked.