### PR TITLE
Don't allow transactions to swamp events

### DIFF
--- a/src/builder_state.rs
+++ b/src/builder_state.rs
@@ -133,15 +133,6 @@ pub struct DAProposalInfo<TYPES: NodeType> {
 
 #[derive(Debug)]
 pub struct BuilderState<TYPES: NodeType> {
-    /// timestamp to tx hash, used for ordering for the transactions
-    // pub timestamp_to_tx: BTreeMap<TxTimeStamp, Commitment<TYPES::Transaction>>,
-
-    /// transaction hash to available transaction data
-    // pub tx_hash_to_available_txns: HashMap<
-    //     Commitment<TYPES::Transaction>,
-    //     (TxTimeStamp, TYPES::Transaction, TransactionSource),
-    // >,
-
     /// Recent included txs set while building blocks
     pub included_txns: HashSet<Commitment<TYPES::Transaction>>,
 
@@ -539,9 +530,8 @@ impl<TYPES: NodeType> BuilderProgress<TYPES> for BuilderState<TYPES> {
 
         self.built_from_proposed_block.leaf_commit = leaf.commit();
 
-        da_proposal_info.txn_commitments.iter().for_each(|txn| {
-            self.included_txns.insert(*txn);
-        });
+        self.included_txns
+            .extend(da_proposal_info.txn_commitments.iter());
         self.tx_queue
             .retain(|tx| !self.included_txns.contains(&tx.commit));
 

--- a/src/builder_state.rs
+++ b/src/builder_state.rs
@@ -23,7 +23,7 @@ use async_compatibility_layer::{art::async_spawn, channel::UnboundedReceiver};
 use async_lock::RwLock;
 use async_trait::async_trait;
 use core::panic;
-use futures::{channel::mpsc::TryRecvError, StreamExt};
+use futures::StreamExt;
 
 #[cfg(async_executor_impl = "async-std")]
 use async_std::task::spawn_blocking;
@@ -31,11 +31,11 @@ use async_std::task::spawn_blocking;
 use tokio::task::spawn_blocking;
 
 use std::collections::{HashMap, HashSet};
+use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::Instant;
 use std::{cmp::PartialEq, num::NonZeroUsize};
 use std::{collections::hash_map::Entry, time::Duration};
-use std::{collections::VecDeque, fmt::Debug};
 
 pub type TxTimeStamp = u128;
 
@@ -250,64 +250,6 @@ pub trait BuilderProgress<TYPES: NodeType> {
 
 #[async_trait]
 impl<TYPES: NodeType> BuilderProgress<TYPES> for BuilderState<TYPES> {
-    // /// processing the external i.e private mempool transaction
-    // fn process_external_transaction(&mut self, txns: Arc<Vec<TYPES::Transaction>>) {
-    //     // PRIVATE MEMPOOL TRANSACTION PROCESSING
-    //     tracing::debug!("Processing external transactions");
-    //     // If it already exists, then discard it. Decide the existence based on the tx_hash_tx and check in both the local pool and already included txns
-    //     txns.iter().for_each(|tx| {
-    //         let tx_hash = tx.commit();
-    //         tracing::debug!("Transaction hash: {:?}", tx_hash);
-    //         if self.tx_hash_to_available_txns.contains_key(&tx_hash)
-    //             || self.included_txns.contains(&tx_hash) || self.included_txns_old.contains(&tx_hash) || self.included_txns_expiring.contains(&tx_hash)
-    //         {
-    //             tracing::debug!("Transaction already exists in the builderinfo.txid_to_tx hashmap, So we can ignore it");
-    //         } else {
-    //             // get the current timestamp in nanoseconds; it used for ordering the transactions
-    //             let tx_timestamp = SystemTime::now()
-    //                 .duration_since(SystemTime::UNIX_EPOCH)
-    //                 .unwrap_or(Duration::new(0, 0))
-    //                 .as_nanos();
-
-    //             // insert into both timestamp_tx and tx_hash_tx maps
-    //             // self.timestamp_to_tx.insert(tx_timestamp, tx_hash);
-    //             self.tx_hash_to_available_txns
-    //                 .insert(tx_hash, (tx_timestamp, tx.clone(), TransactionSource::External));
-    //         }
-    // });
-    // }
-
-    // /// processing the hotshot i.e public mempool transaction
-    // #[tracing::instrument(skip_all, name = "process hotshot transaction",
-    //                                 fields(builder_built_from_proposed_block = %self.built_from_proposed_block))]
-    // fn process_hotshot_transaction(&mut self, txns: Arc<Vec<TYPES::Transaction>>) {
-    //     // Hotshot Public Mempool txns processing
-    //     tracing::debug!("Processing hotshot transactions");
-    //     // If it already exists, then discard it. Decide the existence based on the tx_hash_tx and check in both the local pool and already included txns
-    //     txns.iter().for_each(|tx| {
-    //         let tx_hash = tx.commit();
-    //         tracing::debug!("Transaction hash: {:?}", tx_hash);
-    //         // HOTSHOT MEMPOOL TRANSACTION PROCESSING
-    //         // If it already exists, then discard it. Decide the existence based on the tx_hash_tx and check in both the local pool and already included txns
-    //         if self.tx_hash_to_available_txns.contains_key(&tx_hash)
-    //         || self.included_txns.contains(&tx_hash) || self.included_txns_old.contains(&tx_hash) || self.included_txns_expiring.contains(&tx_hash)
-    //         {
-    //             tracing::debug!("Transaction already exists in the builderinfo.txid_to_tx hashmap, So we can ignore it");
-    //         } else {
-    //             // get the current timestamp in nanoseconds
-    //             let tx_timestamp = SystemTime::now()
-    //                 .duration_since(SystemTime::UNIX_EPOCH)
-    //                 .unwrap_or(Duration::new(0, 0))
-    //                 .as_nanos();
-
-    //             // insert into both timestamp_tx and tx_hash_tx maps
-    //             self.timestamp_to_tx.insert(tx_timestamp, tx_hash);
-    //             self.tx_hash_to_available_txns
-    //                 .insert(tx_hash, (tx_timestamp, tx.clone(), TransactionSource::HotShot));
-    //         }
-    //     });
-    // }
-
     /// processing the DA proposal
     #[tracing::instrument(skip_all, name = "process da proposal",
                                     fields(builder_built_from_proposed_block = %self.built_from_proposed_block))]
@@ -596,11 +538,8 @@ impl<TYPES: NodeType> BuilderProgress<TYPES> for BuilderState<TYPES> {
         da_proposal_info.txn_commitments.iter().for_each(|txn| {
             self.included_txns.insert(*txn);
         });
-        self.tx_queue = self
-            .tx_queue
-            .into_iter()
-            .filter(|tx| (&self.included_txns).contains(&tx.commit))
-            .collect();
+        self.tx_queue
+            .retain(|tx| !self.included_txns.contains(&tx.commit));
 
         // register the spawned builder state to spawned_builder_states in the global state
         self.global_state.write_arc().await.register_builder_state(
@@ -882,8 +821,6 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
         txn_garbage_collect_duration: Duration,
     ) -> Self {
         BuilderState {
-            // timestamp_to_tx: BTreeMap::new(),
-            // tx_hash_to_available_txns: HashMap::new(),
             included_txns: HashSet::new(),
             included_txns_old: HashSet::new(),
             included_txns_expiring: HashSet::new(),
@@ -930,8 +867,6 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
         };
 
         BuilderState {
-            // timestamp_to_tx: self.timestamp_to_tx.clone(),
-            // tx_hash_to_available_txns: self.tx_hash_to_available_txns.clone(),
             included_txns,
             included_txns_old,
             included_txns_expiring,

--- a/src/builder_state.rs
+++ b/src/builder_state.rs
@@ -13,7 +13,7 @@ use hotshot_types::{
 
 use committable::{Commitment, Committable};
 
-use crate::service::GlobalState;
+use crate::service::{GlobalState, ReceivedTransaction};
 use async_broadcast::broadcast;
 use async_broadcast::Receiver as BroadcastReceiver;
 use async_broadcast::Sender as BroadcastSender;
@@ -30,16 +30,12 @@ use async_std::task::spawn_blocking;
 #[cfg(async_executor_impl = "tokio")]
 use tokio::task::spawn_blocking;
 
-use std::fmt::Debug;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Instant;
-use std::time::SystemTime;
-use std::{
-    cmp::max,
-    collections::{BTreeMap, HashMap, HashSet},
-};
 use std::{cmp::PartialEq, num::NonZeroUsize};
 use std::{collections::hash_map::Entry, time::Duration};
+use std::{collections::VecDeque, fmt::Debug};
 
 pub type TxTimeStamp = u128;
 
@@ -138,13 +134,13 @@ pub struct DAProposalInfo<TYPES: NodeType> {
 #[derive(Debug)]
 pub struct BuilderState<TYPES: NodeType> {
     /// timestamp to tx hash, used for ordering for the transactions
-    pub timestamp_to_tx: BTreeMap<TxTimeStamp, Commitment<TYPES::Transaction>>,
+    // pub timestamp_to_tx: BTreeMap<TxTimeStamp, Commitment<TYPES::Transaction>>,
 
     /// transaction hash to available transaction data
-    pub tx_hash_to_available_txns: HashMap<
-        Commitment<TYPES::Transaction>,
-        (TxTimeStamp, TYPES::Transaction, TransactionSource),
-    >,
+    // pub tx_hash_to_available_txns: HashMap<
+    //     Commitment<TYPES::Transaction>,
+    //     (TxTimeStamp, TYPES::Transaction, TransactionSource),
+    // >,
 
     /// Recent included txs set while building blocks
     pub included_txns: HashSet<Commitment<TYPES::Transaction>>,
@@ -169,7 +165,7 @@ pub struct BuilderState<TYPES: NodeType> {
 
     // Channel Receivers for the HotShot events, Tx_receiver could also receive the external transactions
     /// transaction receiver
-    pub tx_receiver: BroadcastReceiver<MessageType<TYPES>>,
+    // pub tx_receiver: BroadcastReceiver<MessageType<TYPES>>,
 
     /// decide receiver
     pub decide_receiver: BroadcastReceiver<MessageType<TYPES>>,
@@ -182,6 +178,9 @@ pub struct BuilderState<TYPES: NodeType> {
 
     /// channel receiver for the block requests
     pub req_receiver: BroadcastReceiver<MessageType<TYPES>>,
+
+    /// transaction queue handle, defined in service.rs
+    pub tx_queue: Arc<RwLock<VecDeque<ReceivedTransaction<TYPES>>>>,
 
     /// global state handle, defined in the service.rs
     pub global_state: Arc<RwLock<GlobalState<TYPES>>>,
@@ -212,10 +211,10 @@ pub struct BuilderState<TYPES: NodeType> {
 #[async_trait]
 pub trait BuilderProgress<TYPES: NodeType> {
     /// process the external transaction
-    fn process_external_transaction(&mut self, txns: Arc<Vec<TYPES::Transaction>>);
+    // fn process_external_transaction(&mut self, txns: Arc<Vec<TYPES::Transaction>>);
 
     /// process the hotshot transaction
-    fn process_hotshot_transaction(&mut self, tx: Arc<Vec<TYPES::Transaction>>);
+    // fn process_hotshot_transaction(&mut self, tx: Arc<Vec<TYPES::Transaction>>);
 
     /// process the DA proposal
     async fn process_da_proposal(&mut self, da_msg: DaProposalMessage<TYPES>);
@@ -251,63 +250,63 @@ pub trait BuilderProgress<TYPES: NodeType> {
 
 #[async_trait]
 impl<TYPES: NodeType> BuilderProgress<TYPES> for BuilderState<TYPES> {
-    /// processing the external i.e private mempool transaction
-    fn process_external_transaction(&mut self, txns: Arc<Vec<TYPES::Transaction>>) {
-        // PRIVATE MEMPOOL TRANSACTION PROCESSING
-        tracing::debug!("Processing external transactions");
-        // If it already exists, then discard it. Decide the existence based on the tx_hash_tx and check in both the local pool and already included txns
-        txns.iter().for_each(|tx| {
-            let tx_hash = tx.commit();
-            tracing::debug!("Transaction hash: {:?}", tx_hash);
-            if self.tx_hash_to_available_txns.contains_key(&tx_hash)
-                || self.included_txns.contains(&tx_hash) || self.included_txns_old.contains(&tx_hash) || self.included_txns_expiring.contains(&tx_hash)
-            {
-                tracing::debug!("Transaction already exists in the builderinfo.txid_to_tx hashmap, So we can ignore it");
-            } else {
-                // get the current timestamp in nanoseconds; it used for ordering the transactions
-                let tx_timestamp = SystemTime::now()
-                    .duration_since(SystemTime::UNIX_EPOCH)
-                    .unwrap_or(Duration::new(0, 0))
-                    .as_nanos();
+    // /// processing the external i.e private mempool transaction
+    // fn process_external_transaction(&mut self, txns: Arc<Vec<TYPES::Transaction>>) {
+    //     // PRIVATE MEMPOOL TRANSACTION PROCESSING
+    //     tracing::debug!("Processing external transactions");
+    //     // If it already exists, then discard it. Decide the existence based on the tx_hash_tx and check in both the local pool and already included txns
+    //     txns.iter().for_each(|tx| {
+    //         let tx_hash = tx.commit();
+    //         tracing::debug!("Transaction hash: {:?}", tx_hash);
+    //         if self.tx_hash_to_available_txns.contains_key(&tx_hash)
+    //             || self.included_txns.contains(&tx_hash) || self.included_txns_old.contains(&tx_hash) || self.included_txns_expiring.contains(&tx_hash)
+    //         {
+    //             tracing::debug!("Transaction already exists in the builderinfo.txid_to_tx hashmap, So we can ignore it");
+    //         } else {
+    //             // get the current timestamp in nanoseconds; it used for ordering the transactions
+    //             let tx_timestamp = SystemTime::now()
+    //                 .duration_since(SystemTime::UNIX_EPOCH)
+    //                 .unwrap_or(Duration::new(0, 0))
+    //                 .as_nanos();
 
-                // insert into both timestamp_tx and tx_hash_tx maps
-                self.timestamp_to_tx.insert(tx_timestamp, tx_hash);
-                self.tx_hash_to_available_txns
-                    .insert(tx_hash, (tx_timestamp, tx.clone(), TransactionSource::External));
-            }
-    });
-    }
+    //             // insert into both timestamp_tx and tx_hash_tx maps
+    //             // self.timestamp_to_tx.insert(tx_timestamp, tx_hash);
+    //             self.tx_hash_to_available_txns
+    //                 .insert(tx_hash, (tx_timestamp, tx.clone(), TransactionSource::External));
+    //         }
+    // });
+    // }
 
-    /// processing the hotshot i.e public mempool transaction
-    #[tracing::instrument(skip_all, name = "process hotshot transaction",
-                                    fields(builder_built_from_proposed_block = %self.built_from_proposed_block))]
-    fn process_hotshot_transaction(&mut self, txns: Arc<Vec<TYPES::Transaction>>) {
-        // Hotshot Public Mempool txns processing
-        tracing::debug!("Processing hotshot transactions");
-        // If it already exists, then discard it. Decide the existence based on the tx_hash_tx and check in both the local pool and already included txns
-        txns.iter().for_each(|tx| {
-            let tx_hash = tx.commit();
-            tracing::debug!("Transaction hash: {:?}", tx_hash);
-            // HOTSHOT MEMPOOL TRANSACTION PROCESSING
-            // If it already exists, then discard it. Decide the existence based on the tx_hash_tx and check in both the local pool and already included txns
-            if self.tx_hash_to_available_txns.contains_key(&tx_hash)
-            || self.included_txns.contains(&tx_hash) || self.included_txns_old.contains(&tx_hash) || self.included_txns_expiring.contains(&tx_hash)
-            {
-                tracing::debug!("Transaction already exists in the builderinfo.txid_to_tx hashmap, So we can ignore it");
-            } else {
-                // get the current timestamp in nanoseconds
-                let tx_timestamp = SystemTime::now()
-                    .duration_since(SystemTime::UNIX_EPOCH)
-                    .unwrap_or(Duration::new(0, 0))
-                    .as_nanos();
+    // /// processing the hotshot i.e public mempool transaction
+    // #[tracing::instrument(skip_all, name = "process hotshot transaction",
+    //                                 fields(builder_built_from_proposed_block = %self.built_from_proposed_block))]
+    // fn process_hotshot_transaction(&mut self, txns: Arc<Vec<TYPES::Transaction>>) {
+    //     // Hotshot Public Mempool txns processing
+    //     tracing::debug!("Processing hotshot transactions");
+    //     // If it already exists, then discard it. Decide the existence based on the tx_hash_tx and check in both the local pool and already included txns
+    //     txns.iter().for_each(|tx| {
+    //         let tx_hash = tx.commit();
+    //         tracing::debug!("Transaction hash: {:?}", tx_hash);
+    //         // HOTSHOT MEMPOOL TRANSACTION PROCESSING
+    //         // If it already exists, then discard it. Decide the existence based on the tx_hash_tx and check in both the local pool and already included txns
+    //         if self.tx_hash_to_available_txns.contains_key(&tx_hash)
+    //         || self.included_txns.contains(&tx_hash) || self.included_txns_old.contains(&tx_hash) || self.included_txns_expiring.contains(&tx_hash)
+    //         {
+    //             tracing::debug!("Transaction already exists in the builderinfo.txid_to_tx hashmap, So we can ignore it");
+    //         } else {
+    //             // get the current timestamp in nanoseconds
+    //             let tx_timestamp = SystemTime::now()
+    //                 .duration_since(SystemTime::UNIX_EPOCH)
+    //                 .unwrap_or(Duration::new(0, 0))
+    //                 .as_nanos();
 
-                // insert into both timestamp_tx and tx_hash_tx maps
-                self.timestamp_to_tx.insert(tx_timestamp, tx_hash);
-                self.tx_hash_to_available_txns
-                    .insert(tx_hash, (tx_timestamp, tx.clone(), TransactionSource::HotShot));
-            }
-        });
-    }
+    //             // insert into both timestamp_tx and tx_hash_tx maps
+    //             self.timestamp_to_tx.insert(tx_timestamp, tx_hash);
+    //             self.tx_hash_to_available_txns
+    //                 .insert(tx_hash, (tx_timestamp, tx.clone(), TransactionSource::HotShot));
+    //         }
+    //     });
+    // }
 
     /// processing the DA proposal
     #[tracing::instrument(skip_all, name = "process da proposal",
@@ -596,11 +595,7 @@ impl<TYPES: NodeType> BuilderProgress<TYPES> for BuilderState<TYPES> {
         self.built_from_proposed_block.leaf_commit = leaf.commit();
 
         da_proposal_info.txn_commitments.iter().for_each(|txn| {
-            if let Entry::Occupied(txn_info) = self.tx_hash_to_available_txns.entry(*txn) {
-                self.timestamp_to_tx.remove(&txn_info.get().0);
-                self.included_txns.insert(*txn);
-                txn_info.remove_entry();
-            }
+            self.included_txns.insert(*txn);
         });
 
         // register the spawned builder state to spawned_builder_states in the global state
@@ -621,46 +616,33 @@ impl<TYPES: NodeType> BuilderProgress<TYPES> for BuilderState<TYPES> {
         matching_vid: VidCommitment,
         requested_view_number: TYPES::Time,
     ) -> Option<BuildBlockInfo<TYPES>> {
-        // try to provide atleast one txn inside the block, ideally this should be a threshold through configurable value,
-        // if it gets non-zero before timeout return, otherwise return after timeout
-        if self.timestamp_to_tx.is_empty() {
-            let timeout_after = Instant::now() + self.maximize_txn_capture_timeout;
-            let sleep_interval = self.maximize_txn_capture_timeout / 10;
-            loop {
-                if let Ok(MessageType::TransactionMessage(rtx_msg)) = self.tx_receiver.try_recv() {
-                    tracing::debug!(
-                        "Received ({:?}) txns msg in builder {:?}",
-                        rtx_msg.txns.len(),
-                        self.built_from_proposed_block,
-                    );
-                    if rtx_msg.tx_type == TransactionSource::HotShot {
-                        self.process_hotshot_transaction(rtx_msg.txns);
+        let mut txns = Vec::new();
+        let timeout_after = Instant::now() + self.maximize_txn_capture_timeout;
+        let sleep_interval = self.maximize_txn_capture_timeout / 10;
+        while Instant::now() <= timeout_after {
+            txns = self
+                .tx_queue
+                .read_arc()
+                .await
+                .iter()
+                .filter_map(|txn| {
+                    if self.included_txns.contains(&txn.commit)
+                        || self.included_txns_old.contains(&txn.commit)
+                        || self.included_txns_expiring.contains(&txn.commit)
+                    {
+                        None
                     } else {
-                        self.process_external_transaction(rtx_msg.txns);
+                        Some(txn.tx.clone())
                     }
-                    tracing::debug!("tx map size: {}", self.tx_hash_to_available_txns.len());
-                }
-                // return if non-zero txns are available
-                if !self.timestamp_to_tx.is_empty() {
-                    break;
-                }
-                // if would timeout before next wake, return
-                if Instant::now() + sleep_interval > timeout_after {
-                    break;
-                }
-
+                })
+                .collect();
+            if txns.is_empty() && (Instant::now() + sleep_interval) <= timeout_after {
                 async_sleep(sleep_interval).await;
             }
         }
-
-        if let Ok((payload, metadata)) = <TYPES::BlockPayload as BlockPayload>::from_transactions(
-            self.timestamp_to_tx.iter().filter_map(|(_ts, tx_hash)| {
-                self.tx_hash_to_available_txns
-                    .get(tx_hash)
-                    .map(|(_ts, tx, _source)| tx.clone())
-            }),
-            &self.instance_state,
-        ) {
+        if let Ok((payload, metadata)) =
+            <TYPES::BlockPayload as BlockPayload>::from_transactions(txns, &self.instance_state)
+        {
             let builder_hash = payload.builder_commitment(&metadata);
             // count the number of txns
             let txn_count = payload.num_transactions(&metadata);
@@ -801,29 +783,6 @@ impl<TYPES: NodeType> BuilderProgress<TYPES> for BuilderState<TYPES> {
         let _builder_handle = async_spawn(async move {
             loop {
                 tracing::debug!("Builder event loop");
-                // read and process up to 1/4 of the channel capacity of available txns
-                let mut message_counter = 0;
-                let max_loop_count = max(self.tx_receiver.capacity() / 4, 1);
-                while let Ok(tx) = self.tx_receiver.try_recv() {
-                    if message_counter >= max_loop_count {
-                        break;
-                    }
-                    message_counter += 1;
-                    if let MessageType::TransactionMessage(rtx_msg) = tx {
-                        tracing::debug!(
-                            "Received ({:?}) txns msg in builder {:?}",
-                            rtx_msg.txns.len(),
-                            self.built_from_proposed_block,
-                        );
-                        if rtx_msg.tx_type == TransactionSource::HotShot {
-                            self.process_hotshot_transaction(rtx_msg.txns);
-                        } else {
-                            self.process_external_transaction(rtx_msg.txns);
-                        }
-                        tracing::debug!("tx map size: {}", self.tx_hash_to_available_txns.len());
-                    }
-                }
-
                 futures::select! {
                     req = self.req_receiver.next() => {
                         tracing::debug!("Received request msg in builder {:?}: {:?}", self.built_from_proposed_block.view_number, req);
@@ -842,28 +801,6 @@ impl<TYPES: NodeType> BuilderProgress<TYPES> for BuilderState<TYPES> {
                             }
                             None => {
                                 tracing::info!("No more request messages to consume");
-                            }
-                        }
-                    },
-                    tx = self.tx_receiver.next() => {
-                        match tx {
-                            Some(tx) => {
-                                if let MessageType::TransactionMessage(rtx_msg) = tx {
-                                    tracing::debug!(
-                                        "Received ({:?}) txns msg in builder {:?}",
-                                        rtx_msg.txns.len(),
-                                        self.built_from_proposed_block,
-                                    );
-                                    if rtx_msg.tx_type == TransactionSource::HotShot {
-                                        self.process_hotshot_transaction(rtx_msg.txns);
-                                    } else {
-                                        self.process_external_transaction(rtx_msg.txns);
-                                    }
-                                    tracing::debug!("tx map size: {}", self.tx_hash_to_available_txns.len());
-                                }
-                            }
-                            None => {
-                                tracing::info!("No more tx messages to consume");
                             }
                         }
                     },
@@ -939,11 +876,12 @@ pub enum MessageType<TYPES: NodeType> {
 impl<TYPES: NodeType> BuilderState<TYPES> {
     pub fn new(
         built_from_proposed_block: BuiltFromProposedBlock<TYPES>,
-        tx_receiver: BroadcastReceiver<MessageType<TYPES>>,
+        // tx_receiver: BroadcastReceiver<MessageType<TYPES>>,
         decide_receiver: BroadcastReceiver<MessageType<TYPES>>,
         da_proposal_receiver: BroadcastReceiver<MessageType<TYPES>>,
         qc_receiver: BroadcastReceiver<MessageType<TYPES>>,
         req_receiver: BroadcastReceiver<MessageType<TYPES>>,
+        tx_queue: Arc<RwLock<VecDeque<ReceivedTransaction<TYPES>>>>,
         global_state: Arc<RwLock<GlobalState<TYPES>>>,
         num_nodes: NonZeroUsize,
         maximize_txn_capture_timeout: Duration,
@@ -952,19 +890,20 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
         txn_garbage_collect_duration: Duration,
     ) -> Self {
         BuilderState {
-            timestamp_to_tx: BTreeMap::new(),
-            tx_hash_to_available_txns: HashMap::new(),
+            // timestamp_to_tx: BTreeMap::new(),
+            // tx_hash_to_available_txns: HashMap::new(),
             included_txns: HashSet::new(),
             included_txns_old: HashSet::new(),
             included_txns_expiring: HashSet::new(),
             built_from_proposed_block,
-            tx_receiver,
+            // tx_receiver,
             decide_receiver,
             da_proposal_receiver,
             qc_receiver,
             req_receiver,
             da_proposal_payload_commit_to_da_proposal: HashMap::new(),
             quorum_proposal_payload_commit_to_quorum_proposal: HashMap::new(),
+            tx_queue,
             global_state,
             builder_commitments: HashSet::new(),
             total_nodes: num_nodes,
@@ -999,19 +938,20 @@ impl<TYPES: NodeType> BuilderState<TYPES> {
         };
 
         BuilderState {
-            timestamp_to_tx: self.timestamp_to_tx.clone(),
-            tx_hash_to_available_txns: self.tx_hash_to_available_txns.clone(),
+            // timestamp_to_tx: self.timestamp_to_tx.clone(),
+            // tx_hash_to_available_txns: self.tx_hash_to_available_txns.clone(),
             included_txns,
             included_txns_old,
             included_txns_expiring,
             built_from_proposed_block: self.built_from_proposed_block.clone(),
-            tx_receiver: self.tx_receiver.clone(),
+            // tx_receiver: self.tx_receiver.clone(),
             decide_receiver: self.decide_receiver.clone(),
             da_proposal_receiver: self.da_proposal_receiver.clone(),
             qc_receiver: self.qc_receiver.clone(),
             req_receiver,
             da_proposal_payload_commit_to_da_proposal: HashMap::new(),
             quorum_proposal_payload_commit_to_quorum_proposal: HashMap::new(),
+            tx_queue: self.tx_queue.clone(),
             global_state: self.global_state.clone(),
             builder_commitments: self.builder_commitments.clone(),
             total_nodes: self.total_nodes,

--- a/src/service.rs
+++ b/src/service.rs
@@ -814,9 +814,6 @@ async fn connect_to_events_service<Types: NodeType>(
 Running Non-Permissioned Builder Service
 */
 pub async fn run_non_permissioned_standalone_builder_service<Types: NodeType>(
-    // sending a transaction from the hotshot mempool to the builder states
-    // tx_sender: BroadcastSender<MessageType<Types>>,
-
     // sending a DA proposal from the hotshot to the builder states
     da_sender: BroadcastSender<MessageType<Types>>,
 
@@ -1119,12 +1116,6 @@ pub(crate) async fn handle_received_txns<Types: NodeType>(
     source: TransactionSource,
 ) -> Result<Vec<Commitment<<Types as NodeType>::Transaction>>, BuildError> {
     let mut results = Vec::with_capacity(txns.len());
-    // let results: Vec<Commitment<<Types as NodeType>::Transaction>> = txns.iter().map(|tx| tx.commit()).collect();
-    // send the whole txn batch to the tx_sender, might get duplicate transactions but builder needs to filter them
-    // let tx_msg = TransactionMessage::<Types> {
-    //     txns: Arc::new(txns.clone()),
-    //     tx_type: source.clone(),
-    // };
     let time_in = Instant::now();
     for tx in txns.into_iter() {
         let commit = tx.commit();

--- a/src/testing/basic_test.rs
+++ b/src/testing/basic_test.rs
@@ -88,8 +88,8 @@ mod tests {
         const TEST_NUM_NODES_IN_VID_COMPUTATION: usize = 4;
 
         // settingup the broadcast channels i.e [From hostshot: (tx, decide, da, qc, )], [From api:(req - broadcast, res - mpsc channel) ]
-        let (tx_sender, tx_receiver) =
-            broadcast::<MessageType<TestTypes>>(num_test_messages * multiplication_factor);
+        // let (tx_sender, tx_receiver) =
+        //     broadcast::<MessageType<TestTypes>>(num_test_messages * multiplication_factor);
         let (decide_sender, decide_receiver) =
             broadcast::<MessageType<TestTypes>>(num_test_messages * multiplication_factor);
         let (da_sender, da_receiver) =
@@ -106,7 +106,7 @@ mod tests {
         // instantiate the global state also
         let global_state = GlobalState::<TestTypes>::new(
             bootstrap_sender,
-            tx_sender.clone(),
+            // tx_sender.clone(),
             txn_queue.clone(),
             vid_commitment(&[], 8),
             ViewNumber::new(0),
@@ -287,7 +287,7 @@ mod tests {
             // currently this step happens in the service.rs, wheneve we receiver an hotshot event
             tracing::debug!("Sending transaction message: {:?}", tx);
             handle_received_txns(
-                &tx_sender,
+                // &tx_sender,
                 &txn_queue,
                 vec![tx.clone()],
                 TransactionSource::HotShot,
@@ -327,6 +327,7 @@ mod tests {
         //let global_state_clone = arc_rwlock_global_state.clone();
         let arc_rwlock_global_state = Arc::new(RwLock::new(global_state));
         let arc_rwlock_global_state_clone = arc_rwlock_global_state.clone();
+        let arc_rwlock_tx_queue = txn_queue.clone();
         let handle = async_spawn(async move {
             let built_from_info = BuiltFromProposedBlock {
                 view_number: ViewNumber::new(0),
@@ -336,11 +337,12 @@ mod tests {
             };
             let builder_state = BuilderState::<TestTypes>::new(
                 built_from_info,
-                tx_receiver,
+                // tx_receiver,
                 decide_receiver,
                 da_receiver,
                 qc_receiver,
                 bootstrap_receiver,
+                arc_rwlock_tx_queue,
                 arc_rwlock_global_state_clone,
                 NonZeroUsize::new(TEST_NUM_NODES_IN_VID_COMPUTATION).unwrap(),
                 Duration::from_millis(10), // max time to wait for non-zero txn block

--- a/src/testing/basic_test.rs
+++ b/src/testing/basic_test.rs
@@ -87,9 +87,6 @@ mod tests {
         const TEST_NUM_NODES_IN_VID_COMPUTATION: usize = 4;
 
         // settingup the broadcast channels i.e [From hostshot: (tx, decide, da, qc, )], [From api:(req - broadcast, res - mpsc channel) ]
-        let (tx_sender, tx_receiver) = broadcast::<Arc<ReceivedTransaction<TestTypes>>>(
-            num_test_messages * multiplication_factor,
-        );
         let (decide_sender, decide_receiver) =
             broadcast::<MessageType<TestTypes>>(num_test_messages * multiplication_factor);
         let (da_sender, da_receiver) =


### PR DESCRIPTION
Should result in improvements to performance under load; will require updates in sequencer.
Progress on https://github.com/EspressoSystems/hotshot-builder-core/issues/173

### This PR:
* moves transaction processing to a separate, at use, async loop from triggering hotshot events
* allows the async_broadcast queue to drop (oldest) transactions from a BuilderState that isn't actively processing them
  *  would prefer a different drop strategy, but that would require implementing our own channel
  *  will need to split ESPRESSO_BUILDER_CHANNEL_CAPACITY into ESPRESSO_BUILDER_HS_EVENTS_CHANNEL_CAPACITY (small - default of 32 should be more than enough) and ESPRESSO_BUILDER_TXNS_CHANNEL_CAPACITY (much larger)

### This PR does not:
* fix the still unidentified async context panic

### Key places to review:
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
<!-- Or directly comment on those files/lines to make it easier for the reviewers -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
