### PR TITLE
change log to debug

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -903,7 +903,7 @@ pub async fn run_non_permissioned_standalone_builder_service<Types: NodeType>(
                         handle_qc_event(&qc_sender, Arc::new(proposal), sender, leader).await;
                     }
                     _ => {
-                        tracing::error!("Unhandled event from Builder");
+                        tracing::debug!("Unhandled event from Builder");
                     }
                 }
             }


### PR DESCRIPTION
We now receive all the events from the event stream, so there can be a lot of events that the builder doesn't care about